### PR TITLE
CMakeLists.txt added

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(modbus-utils VERSION 1.0.0 LANGUAGES C)
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(MODBUS REQUIRED IMPORTED_TARGET libmodbus)
+
+add_executable(modbus_client "${CMAKE_CURRENT_SOURCE_DIR}/modbus_client/modbus_client.c")
+target_link_libraries(modbus_client PkgConfig::MODBUS)
+target_include_directories(modbus_client PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/common" "${MODBUS_INCLUDE_DIRS}")
+
+add_executable(modbus_server "${CMAKE_CURRENT_SOURCE_DIR}/modbus_server/modbus_server.c")
+target_link_libraries(modbus_server PkgConfig::MODBUS)
+target_include_directories(modbus_server PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/common" "${MODBUS_INCLUDE_DIRS}")

--- a/modbus_client/modbus_client.c
+++ b/modbus_client/modbus_client.c
@@ -28,7 +28,7 @@
 #include <string.h>
 #include <stdint.h>
 
-#include "modbus.h"
+#include <modbus.h>
 #include "errno.h"
 
 #include "mbu-common.h"


### PR DESCRIPTION
This file might be used by QtCreator and is also designed to use `libmodbus` installed into operating system. This will allow to package `modbus-utils` for distributions. This file is not interfering `.pro` file builds in any way.